### PR TITLE
overflow of t time variable corrected

### DIFF
--- a/include/mgos_ir.h
+++ b/include/mgos_ir.h
@@ -24,7 +24,7 @@ struct mgos_irrecv_nec_s {
     uint8_t byte[4];
     uint32_t dword;
   } code;
-  uint32_t t;
+  uint64_t t;
   uint8_t bit;
 };
 

--- a/src/mgos_ir.c
+++ b/src/mgos_ir.c
@@ -12,7 +12,7 @@ static IRAM void irrecv_nec_handler(int pin, void *arg)
 {
   struct mgos_irrecv_nec_s *obj = (struct mgos_irrecv_nec_s *)arg;
   // get microseconds
-  uint32_t t = 1000000 * mgos_uptime();
+  uint64_t t = 1000000 * mgos_uptime();
   // 0-1 transition?
   if (mgos_gpio_read(pin)) {
     // start counter


### PR DESCRIPTION
I corrected t variable from uint32_t to uint64_t. In previous overflowed after some more than 4000seconds of uptime (in depend of mgos_uptime() )
JL